### PR TITLE
Fix typo in end message

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -127,7 +127,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
             this.log(chalk.green('    kpm restore'));
             this.log(chalk.green('    kpm build'));
             this.log(chalk.green('    k run') + ' for console projects');
-            this.log(chalk.green('    k kestrel') + ' or ' + chalk.green('k web') + 'for web projects');
+            this.log(chalk.green('    k kestrel') + ' or ' + chalk.green('k web') + ' for web projects');
             this.log('\r\n');
         }
     }


### PR DESCRIPTION
This fixes missing space in message shown at the end of generator run
